### PR TITLE
Fix stuck deployment no open ports

### DIFF
--- a/utils/health_server.py
+++ b/utils/health_server.py
@@ -1,0 +1,63 @@
+"""
+Lightweight HTTP health server to satisfy Render's port check.
+
+Runs a tiny HTTP server on the configured port in a background thread,
+responding 200 OK on "/" and "/healthz".
+"""
+
+import http.server
+import socketserver
+import threading
+from typing import Optional
+
+
+class _HealthRequestHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # type: ignore[override]
+        if self.path in ("/", "/healthz", "/livez", "/readyz"):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(b"ok")
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format: str, *args) -> None:  # noqa: A003 - signature required by BaseHTTPRequestHandler
+        # Silence default logging to avoid noisy output in bot logs
+        return
+
+
+class HealthServer:
+    """Embeds a simple HTTP server in a background thread."""
+
+    def __init__(self, host: str = "0.0.0.0", port: int = 8080) -> None:
+        self.host = host
+        self.port = port
+        self._httpd: Optional[socketserver.TCPServer] = None
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+
+        # Create TCPServer with reusable address to handle Render restarts gracefully
+        class ReusableTCPServer(socketserver.TCPServer):
+            allow_reuse_address = True
+
+        self._httpd = ReusableTCPServer((self.host, self.port), _HealthRequestHandler)
+
+        def serve() -> None:
+            assert self._httpd is not None
+            self._httpd.serve_forever()
+
+        self._thread = threading.Thread(target=serve, name="health-server", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._httpd is not None:
+            try:
+                self._httpd.shutdown()
+            finally:
+                self._httpd.server_close()
+                self._httpd = None
+


### PR DESCRIPTION
Add a lightweight HTTP health server to satisfy Render's port check, preventing deployments from hanging on "No open ports detected".

---
<a href="https://cursor.com/background-agent?bcId=bc-1ec5d847-b64e-49df-a8e9-4caafefb9c01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1ec5d847-b64e-49df-a8e9-4caafefb9c01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

